### PR TITLE
Fix buffer-overflow in sha256 string construction

### DIFF
--- a/src/tools/sha256file.cpp
+++ b/src/tools/sha256file.cpp
@@ -103,7 +103,7 @@ string sha256sum(const char *fn) {
         }
     }
     SHA256_Final(sha, &ctx);
-    char res[SHA256_DIGEST_LENGTH * 2];
+    char res[SHA256_DIGEST_LENGTH * 2 + 1];
     for (int i = 0; i < SHA256_DIGEST_LENGTH; i++)
         sprintf(res + (i * 2), "%02x", sha[i]);
     return "sha256:" + std::string(res, SHA256_DIGEST_LENGTH * 2);


### PR DESCRIPTION
Need to leave room for the last null-byte.

**What this PR does / why we need it**: Fixes a crash and stack corruption.

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [X]  Do all new files have an appropriate license header?